### PR TITLE
Support for older Thimbleweed Park versions

### DIFF
--- a/ThimbleweedLibrary/BundleReader_ggpack.cs
+++ b/ThimbleweedLibrary/BundleReader_ggpack.cs
@@ -43,6 +43,11 @@ namespace ThimbleweedLibrary
         public Int64 Offset = -1;
         public int Size = -1;
         public FileTypes FileType = FileTypes.None;
+
+        public override string ToString()
+        {
+            return $"Offset: 0x{Offset:X8} Size: {Size,8} Name: {FileName}";
+        }
     }
 
     public class BundleReader_ggpack : IDisposable
@@ -314,6 +319,9 @@ namespace ThimbleweedLibrary
                         continue;
                     }
                 }
+                //Add last entry (if any)
+                if (bundleEntry != null && bundleEntry.FileName != null)
+                    BundleFiles.Add(bundleEntry);
 
                 //Now correct missing sizes / offsets
                 for (int i = 0; i < BundleFiles.Count; i++)
@@ -322,7 +330,7 @@ namespace ThimbleweedLibrary
                     {
                         BundleFiles[i].Offset = BundleFiles[i - 1].Offset + BundleFiles[i - 1].Size; //BundleFiles[i + 1].Offset - BundleFiles[i - 1].Offset;
                     }
-                    if (BundleFiles[i].Size == 0)
+                    if (BundleFiles[i].Size <= 0)
                     {
                         if (i == BundleFiles.Count - 1) //Last entry - look at difference between data offset and its offset
                         {

--- a/ThimbleweedLibrary/BundleReader_ggpack.cs
+++ b/ThimbleweedLibrary/BundleReader_ggpack.cs
@@ -44,18 +44,30 @@ namespace ThimbleweedLibrary
         //Constructor
         public BundleReader_ggpack(string ResourceFile)
         {
-            BundleFilename = ResourceFile;
-
-            fileReader = new BinaryStream(File.Open(BundleFilename, FileMode.Open));
-
-            if (DetectBundle() == false)
+            try
             {
-                throw new ArgumentException("Invalid ggpack file!");
-            }
+                BundleFilename = ResourceFile;
 
-            BundleFiles = new List<BundleEntry>();
-            ParseFiles();
-            UpdateFileTypes();
+                fileReader = new BinaryStream(File.Open(BundleFilename, FileMode.Open));
+
+                if (DetectBundle() == false)
+                {
+                    throw new ArgumentException("Invalid ggpack file!");
+                }
+
+                BundleFiles = new List<BundleEntry>();
+                ParseFiles();
+                UpdateFileTypes();
+            }
+            catch
+            {
+                try
+                {
+                    Dispose();
+                }
+                catch { }
+                throw;
+            }
         }
 
         //Destructor

--- a/ThimbleweedParkExplorer.sln
+++ b/ThimbleweedParkExplorer.sln
@@ -13,12 +13,12 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84A9868E-87B5-4C0D-A4F5-5C0DBAA54B3A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{78DA1FF4-6D08-4CD3-9734-E7F75D093BC1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/ThimbleweedParkExplorer/formMain.Designer.cs
+++ b/ThimbleweedParkExplorer/formMain.Designer.cs
@@ -85,7 +85,7 @@
             // 
             // openFileDialog1
             // 
-            this.openFileDialog1.Filter = "Ggpack files|*.ggpack1;*.ggpack2";
+            this.openFileDialog1.Filter = "Ggpack files|*.ggpack?";
             // 
             // richTextBoxLog
             // 

--- a/ThimbleweedParkExplorer/formMain.Designer.cs
+++ b/ThimbleweedParkExplorer/formMain.Designer.cs
@@ -102,7 +102,7 @@
             this.richTextBoxLog.ShowSelectionMargin = true;
             this.richTextBoxLog.Size = new System.Drawing.Size(894, 68);
             this.richTextBoxLog.TabIndex = 4;
-            this.richTextBoxLog.Text = "Thimbleweed Park Explorer\nhttp://quickandeasysoftware.net";
+            this.richTextBoxLog.Text = "Thimbleweed Park Explorer\nhttp://quickandeasysoftware.net\n";
             // 
             // panel1
             // 

--- a/ThimbleweedParkExplorer/formMain.cs
+++ b/ThimbleweedParkExplorer/formMain.cs
@@ -52,7 +52,7 @@ namespace ThimbleweedParkExplorer
             InitializeListView();
 
             //Add info to log box
-            richTextBoxLog.Text = Constants.ProgName + " " + Constants.Version + Environment.NewLine + Constants.URL;
+            richTextBoxLog.Text = Constants.ProgName + " " + Constants.Version + Environment.NewLine + Constants.URL + Environment.NewLine;
 
             //Set listview background
             objectListView1.SetNativeBackgroundTiledImage(Properties.Resources.listViewBackground);


### PR DESCRIPTION
I've made some minor fixes + added support for older Thimbleweed Park versions (namely versions before v1421.957 till the very first official release v1296.849).

Method BundleReader_ggpack.DetectBundle() now tries to automatically detect the file version and method DecodeUnbreakableXor() acts accordingly.