### PR TITLE
Support for Return to Monkey Island

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ It uses the following nuget packages:
 
 http://quickandeasysoftware.net
 
+Forked to add support for the recently released "Return to Monkey Island" ([Official website](https://returntomonkeyisland.com))
+Status:
+The files can be read, the contents can be saved to disk. 
+
+Since the game uses longer keys for the decryption algorithm, the keys are extracted from the game's executable the first time a resource file is opened.

--- a/ThimbleweedLibrary/BundleReader_ggpack.cs
+++ b/ThimbleweedLibrary/BundleReader_ggpack.cs
@@ -14,6 +14,7 @@ namespace ThimbleweedLibrary
         Version_918,
         Version_957,
         Version_Delores,
+        Version_RtMI
     }
 
     //For the logging event
@@ -61,7 +62,7 @@ namespace ThimbleweedLibrary
         private string BundleFilename;
         private BinaryStream fileReader;
         private bool _disposed = false;
-        
+
         //Constructor
         public BundleReader_ggpack(string ResourceFile)
         {
@@ -80,14 +81,14 @@ namespace ThimbleweedLibrary
                 ParseFiles();
                 UpdateFileTypes();
             }
-            catch
+            catch (Exception ex)
             {
-                try
-                {
-                    Dispose();
-                }
-                catch { }
-                throw;
+                //try
+                //{
+                //    Dispose();
+                //}
+                //catch { }
+                //throw;
             }
         }
 
@@ -105,7 +106,7 @@ namespace ThimbleweedLibrary
                 {
                     // Dispose any managed objects
                     // ...
-                    fileReader.Dispose();
+                    if (fileReader != null) fileReader.Dispose();
                 }
 
                 // Now disposed of any unmanaged objects
@@ -133,7 +134,7 @@ namespace ThimbleweedLibrary
             using (BinaryStream decReader = new BinaryStream(new MemoryStream())) //Frees when done + underlying stream
             {
                 //Try to decode all versions
-               var fileVersions = Enum.GetValues(typeof(BundleFileVersion)).Cast<BundleFileVersion>().Where(v => v != BundleFileVersion.Unknown); //Build an array of enums but exclude the unknown enum
+                var fileVersions = Enum.GetValues(typeof(BundleFileVersion)).Cast<BundleFileVersion>().Where(v => v != BundleFileVersion.Unknown); //Build an array of enums but exclude the unknown enum
                 foreach (var currentFileVersion in fileVersions)
                 {
                     FileVersion = currentFileVersion;
@@ -172,57 +173,72 @@ namespace ThimbleweedLibrary
         /// <returns></returns>
         private bool DecodeUnbreakableXor(MemoryStream DecodeStream)
         {
-            //Quick hack for Delores
-            byte[] magic_bytes;
-            if (FileVersion == BundleFileVersion.Version_Delores)
-                magic_bytes = magic_bytes_delores;
-            else
-                magic_bytes = magic_bytes_thimbleweed;
-
-
-            var buffer = DecodeStream.ToArray(); //Put the stream data into a buffer
-
-            var buf_len = buffer.Length;
-            var eax = buf_len;
-            var var4 = buf_len & 255;
-            var ebx = 0;
-            int f = FileVersion == BundleFileVersion.Version_957 ? -83 : 109; //Latest version of TP uses -83 here. All the others use 109
-            while (ebx < buf_len)
+            if (FileVersion == BundleFileVersion.Version_RtMI)
             {
-                eax = ebx & 255;
-                eax = eax * f;
-                var ecx = ebx & 15;
-                eax = (eax ^ magic_bytes[ecx]) & 255;
-                ecx = var4;
-                eax = (eax ^ ecx) & 255;
-                buffer[ebx] = Convert.ToByte(buffer[ebx] ^ eax);
-                ecx = ecx ^ buffer[ebx];
-                ebx = ebx + 1;
-                var4 = ecx;
-            }
+                var buffer = DecodeStream.ToArray(); //Put the stream data into a buffer
 
-            if (FileVersion != BundleFileVersion.Version_849 && FileVersion != BundleFileVersion.Version_Delores)
-            {
-                //Loop through in blocks of 16 and xor the 6th and 7th bytes
-                int i = 5;
-                while (i + 1 < buf_len)
-                {
-                    buffer[i] = Convert.ToByte(buffer[i] ^ 0x0D);
-                    buffer[i + 1] = Convert.ToByte(buffer[i + 1] ^ 0x0D);
-                    i += 16;
-                }
-            }
+                RtMIKeyReader.ComputeXOR(ref buffer, BundleFilename);
 
-            //Check everything has decoded
-            if (buffer != null && buffer.Length > 0)
-            {
                 DecodeStream.SetLength(0); //empty the stream
                 DecodeStream.Write(buffer, 0, buffer.Length); //write the decoded bytes back
                 DecodeStream.Position = 0;
 
                 return true;
             }
-            return false;
+            else
+            {
+                //Quick hack for Delores
+                byte[] magic_bytes;
+                if (FileVersion == BundleFileVersion.Version_Delores)
+                    magic_bytes = magic_bytes_delores;
+                else
+                    magic_bytes = magic_bytes_thimbleweed;
+
+
+                var buffer = DecodeStream.ToArray(); //Put the stream data into a buffer
+
+                var buf_len = buffer.Length;
+                var eax = buf_len;
+                var var4 = buf_len & 255;
+                var ebx = 0;
+                int f = FileVersion == BundleFileVersion.Version_957 ? -83 : 109; //Latest version of TP uses -83 here. All the others use 109
+                while (ebx < buf_len)
+                {
+                    eax = ebx & 255;
+                    eax = eax * f;
+                    var ecx = ebx & 15;
+                    eax = (eax ^ magic_bytes[ecx]) & 255;
+                    ecx = var4;
+                    eax = (eax ^ ecx) & 255;
+                    buffer[ebx] = Convert.ToByte(buffer[ebx] ^ eax);
+                    ecx = ecx ^ buffer[ebx];
+                    ebx = ebx + 1;
+                    var4 = ecx;
+                }
+
+                if (FileVersion != BundleFileVersion.Version_849 && FileVersion != BundleFileVersion.Version_Delores)
+                {
+                    //Loop through in blocks of 16 and xor the 6th and 7th bytes
+                    int i = 5;
+                    while (i + 1 < buf_len)
+                    {
+                        buffer[i] = Convert.ToByte(buffer[i] ^ 0x0D);
+                        buffer[i + 1] = Convert.ToByte(buffer[i + 1] ^ 0x0D);
+                        i += 16;
+                    }
+                }
+
+                //Check everything has decoded
+                if (buffer != null && buffer.Length > 0)
+                {
+                    DecodeStream.SetLength(0); //empty the stream
+                    DecodeStream.Write(buffer, 0, buffer.Length); //write the decoded bytes back
+                    DecodeStream.Position = 0;
+
+                    return true;
+                }
+                return false;
+            }
         }
 
         //Parse the bundle, extracting information about the files and adding BundleEntry objects for each
@@ -383,7 +399,7 @@ namespace ThimbleweedLibrary
             }
         }
 
-       
+
         public void SaveFile(int FileNo, string PathAndFileName, Boolean Autodecode = true)
         {
             if (FileNo < 0 || FileNo > BundleFiles.Count)
@@ -401,17 +417,24 @@ namespace ThimbleweedLibrary
                 throw new ArgumentException(FileNo.ToString() + " Invalid file number! Save cancelled.");
             if (BundleFiles[FileNo].Size == 0)
                 //throw new ArgumentException(BundleFiles[FileNo].FileName + " File num " + FileNo.ToString() + " Filesize = 0 Skipping this file.");
-                Log( BundleFiles[FileNo].FileName + " File num " + FileNo.ToString() + " Filesize = 0 Skipping this file.");
+                Log(BundleFiles[FileNo].FileName + " File num " + FileNo.ToString() + " Filesize = 0 Skipping this file.");
 
-            
+
             using (MemoryStream ms = new MemoryStream())
             {
                 fileReader.Position = BundleFiles[FileNo].Offset;
                 CopyStream(fileReader.BaseStream, ms, BundleFiles[FileNo].Size);
                 ms.Position = 0;
 
+                bool skipDecode = false;
+                // In Rtmi, the FMOD .bank files used for audio do not seem to be Xor'd. 
+                // I have not yet determined to what extent the other resource files are encoded. The sound engine's .bank-files definitely aren't encoded.
+                // Although it should be noted that the game uses FMOD's built-in encryption for the files. (The password is easily extracted from the .exe as well)
+                // The .json files seem to contain some amount of readable text after being decoded and not before.
+                if ((FileVersion == BundleFileVersion.Version_RtMI && BundleFiles[FileNo].FileName.ToLowerInvariant().EndsWith(".bank"))) skipDecode = true;
+
                 //Decode data records
-                if (DecodeUnbreakableXor(ms) == true)
+                if (skipDecode || DecodeUnbreakableXor(ms) == true)
                 {
                     ms.Position = 0;
 
@@ -444,5 +467,107 @@ namespace ThimbleweedLibrary
         {
             this.LogEvent?.Invoke(this, new StringEventArgs(e));
         }
+    }
+
+    /// <summary>
+    /// Helps decrypt Return to Monkey Island's resource files.
+    /// 
+    /// Return to Monkey Island seems to use longer keys than previous titles.
+    /// To prevent inclusion of the keys in this project (as the keys themselves might be considered part of the games data and therefore protected by copyright),
+    /// we only distribute the MD5-Checksum of the two data arrays (as well as the first byte of each key)
+    /// 
+    /// Two keys are used, a short 256 byte key beginning with 0x5D and a longer 65536 byte key starting with 0xF7
+    /// </summary>
+    public class RtMIKeyReader
+    {
+        public static byte[] Key1 = null;
+        public static byte[] Key2 = null;
+
+        // short key - checksum
+        private static readonly string Key1Checksum = "B190C421FE7FEAFC77C517A232ABBB4C";
+        // long key - checksum
+        private static readonly string Key2Checksum = "7FAAF6574F27EBD9D2744CC68E4115C8";
+
+        /// <summary>
+        /// Decrypts the files in the fashion used by Return to Monkey Island
+        /// </summary>
+        /// <param name="data">data to en/decrypt</param>
+        /// <param name="fileLocation">used to search for the game's executable if the keys have not yet been loaded.</param>
+        public static void ComputeXOR(ref byte[] data, string fileLocation)
+        {
+            EnsureKeys(fileLocation);
+
+            ushort var = (ushort)(((ushort)data.Length) + (ushort)0x78);
+
+            for (int i = 0; i < data.Length; ++i)
+            {
+                data[i] = (byte)(data[i] ^ (Key1[(byte)((byte)var + (byte)0x78)]) ^ Key2[var]);
+                var = (ushort)(var + (Key1[(byte)var]));
+            }
+        }
+
+        /// <summary>
+        /// Ensure we have the keys.
+        /// </summary>
+        /// <param name="fileLocation">If this directory contains a file called "Return to Monkey Island.exe", use this.</param>
+        /// <exception cref="KeyNotFoundException">thrown if one or both keys could not be extracted</exception>
+        private static void EnsureKeys(string fileLocation)
+        {
+
+            if (Key1 == null || Key2 == null)
+            {
+                // We need to get the Keys from the game executable.
+                // is there an appopriate file in the resource file's directory?
+                string executableName = Path.Combine(Path.GetDirectoryName(fileLocation), "Return to Monkey Island.exe");
+                if (!File.Exists(executableName))
+                {
+                    if (OnSearchForMonkeyIsland != null) executableName = OnSearchForMonkeyIsland();
+                    if (String.IsNullOrWhiteSpace(executableName) || !File.Exists(executableName))
+                    {
+                        throw new KeyNotFoundException("To extract files from Return To Monkey Island, the XOR Keys need to be extracted from the game's executable File. This file was not found.");
+                    }
+                }
+
+                var miexe = File.ReadAllBytes(executableName);
+                Key1 = SearchForKey(miexe, Key1Checksum, 256, 0xD5);
+                Key2 = SearchForKey(miexe, Key2Checksum, 65536, 0xF7);
+
+                if (Key1 == null || Key2 == null)
+                {
+                    string WholeFileChecksum = Checksum(miexe, 0, miexe.Length);
+                    throw new KeyNotFoundException($"The XOR-Key for Return to Monkey Island could not be extracted from the File \"{executableName}\": Checksum {WholeFileChecksum}");
+                }
+            }
+        }
+
+        private static byte[] SearchForKey(byte[] data, string keyChecksum, int keyLengthBytes, byte firstByte)
+        {
+            for (int i = 0; i<data.Length - keyLengthBytes; ++i)
+            {
+                // optimization - including a single byte should be fine.
+                if (data[i] == firstByte)
+                {
+                    string checksum = Checksum(data, i, keyLengthBytes);
+                    if (checksum == keyChecksum)
+                    {
+                        byte[] key = new byte[keyLengthBytes];
+                        for (int x = 0; x < keyLengthBytes; ++x) key[x] = data[i + x];
+                        return key;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private static string Checksum(byte[] buffer, int start, int offset)
+        {
+            using (var MD5 = System.Security.Cryptography.MD5.Create())
+            {
+                return String.Join("", MD5.ComputeHash(buffer, start, offset).Select(s => s.ToString("X2")));
+            }
+        }
+
+        public delegate string SearchForMonkeyIslandExeEvent();
+        public  static event SearchForMonkeyIslandExeEvent OnSearchForMonkeyIsland;
     }
 }

--- a/ThimbleweedParkExplorer/formMain.Designer.cs
+++ b/ThimbleweedParkExplorer/formMain.Designer.cs
@@ -86,7 +86,7 @@
             // 
             // openFileDialog1
             // 
-            this.openFileDialog1.Filter = "Ggpack files|*.ggpack?";
+            this.openFileDialog1.Filter = "Ggpack files|*.ggpack?;*.ggpack??";
             // 
             // richTextBoxLog
             // 

--- a/ThimbleweedParkExplorer/formMain.cs
+++ b/ThimbleweedParkExplorer/formMain.cs
@@ -26,7 +26,7 @@ namespace ThimbleweedParkExplorer
         public formMain()
         {
             InitializeComponent();
-
+            RtMIKeyReader.OnSearchForMonkeyIsland += RtMIKeyReader_OnSearchForMonkeyIsland;
             //Get icon from exe and use for form icon
             Icon = Icon.ExtractAssociatedIcon(System.Reflection.Assembly.GetExecutingAssembly().Location);
 
@@ -60,6 +60,14 @@ namespace ThimbleweedParkExplorer
             EnableDisableControlsContextDependant();
 
             panelBlank.BringToFront();
+        }
+
+        private string RtMIKeyReader_OnSearchForMonkeyIsland()
+        {
+            OpenFileDialog dialog = new OpenFileDialog();
+            dialog.Filter = "Executable File|*.exe";
+            if (dialog.ShowDialog() != DialogResult.OK) return "";
+            return dialog.FileName;
         }
 
         /// <summary>
@@ -699,6 +707,6 @@ namespace ThimbleweedParkExplorer
                 btnSoundPlay.PerformClick();
             }
         }
-        
+
     }
 }


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/44774802/192121607-4f716b3d-63aa-49c6-bf54-3d0490091350.png)

Hello,
I have added support for the encryption method used by Return to Monkey Island. (see screenshot)
The game seems to use far longer keys than the previous ones (256 + 65536 bytes).
I am concerned that these are protected by copyright. I have therefore decided not to include them in the Program itself.
Instead, the first time a pack file from RtMI is opened, the keys are extracted from the game's executable file (included in the source code are merely the first byte of each key and the MD5-Checksum).

I am not familiar enough with Thimbleweed Park's asset files to determine whether there have been significant changes, although I am quite certain that they have been changed quite a bit.
The audio files are not stored in the packs directly, rather using FMODs proprietary .bank format (I have been able to play them just fine in a small test program) - providing a preview will probably be impossible.

The Game contains .json files (in Weird.ggpack5a) that do not look like json (they seem similar to the format used in the "info"-block at the end of the pack file)

The graphics are stored in files with a ".ktxbz" extension. These seem to be compressed (zlib/deflate) Khronos Texture Files (.ktx), although I have not yet been able to display them properly.

Update: Very few tools seem to exist to work with .ktx files; Most of them treat them as invalid.
[This tool](https://github.com/septag/dds-ktx) is able to display them. 

Let me know what you think.
Thanks.
