### PR TITLE
Proper integration of KTX Images

### DIFF
--- a/ThimbleweedParkExplorer/packages.config
+++ b/ThimbleweedParkExplorer/packages.config
@@ -1,10 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="ILMerge" version="2.14.1208" targetFramework="net452" />
-  <package id="MSBuild.ILMerge.Task" version="1.0.5" targetFramework="net452" />
+  <package id="BCnEncoder.Net45" version="0.0.1" targetFramework="net452" />
+  <package id="ILMerge" version="3.0.41" targetFramework="net452" />
+  <package id="MSBuild.ILMerge.Task" version="1.1.3" targetFramework="net452" />
   <package id="NAudio" version="1.8.4" targetFramework="net452" />
-  <package id="NVorbis" version="0.8.5.0" targetFramework="net452" />
+  <package id="NAudio.Vorbis" version="1.5.0" targetFramework="net452" />
+  <package id="NVorbis" version="0.10.4" targetFramework="net452" />
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net40" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net452" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net452" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
   <package id="WindowsAPICodePack-Core" version="1.1.2" targetFramework="net452" />
   <package id="WindowsAPICodePack-Shell" version="1.1.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I found a library to show the KTX-Files.
Well, sort of because the library (https://github.com/Nominom/BCnEncoder.NET) only supports KTX files that are compressed with any of the BCn compression algorithms. As far as I know, all of RtMI's images are BC7-Compressed and work just fine.
The images that appeared blank with the previous tool now display, and if the user enters a *.png-filename when "Saving as Image", the image is decompressed and reencoded as png before saving.
(of course the images are now displayed in the same way as regular png images).

I had to commit the packages.config, so fixing the packages might be necessary to get it to compile...

![grafik](https://user-images.githubusercontent.com/44774802/192168206-57173fd5-c011-4e83-8770-2f70bddf5198.png)

