### PR TITLE
Use InvariantCulture for parsing numbers

### DIFF
--- a/ThimbleweedLibrary/GGDict.cs
+++ b/ThimbleweedLibrary/GGDict.cs
@@ -130,8 +130,8 @@ namespace ThimbleweedLibrary
             return Strings[(int)StringIndex];
         }
 
-        private int ReadInteger() => int.Parse(ReadString());
-        private double ReadFloat() => double.Parse(ReadString());
+        private int ReadInteger() => int.Parse(ReadString(), System.Globalization.CultureInfo.InvariantCulture);
+        private double ReadFloat() => double.Parse(ReadString(), System.Globalization.CultureInfo.InvariantCulture);
 
 
 


### PR DESCRIPTION
Parsing of floating-point numbers fails on cultures that use different ways of writing them, such as using "," as the decimal separator in European languages. This makes it consistent across all cultures.